### PR TITLE
Associate TrueType Font Collection files with the right mime type

### DIFF
--- a/src/common/extern_data.cpp
+++ b/src/common/extern_data.cpp
@@ -2127,7 +2127,7 @@ std::vector<mime_type_t> const mime_types = {
   { "application/x-troff-man",                                { "man" }                                                },
   { "application/x-troff-me",                                 { "me" }                                                 },
   { "application/x-troff-ms",                                 { "ms" }                                                 },
-  { "application/x-truetype-font",                            { "ttf", "otf" }                                         },
+  { "application/x-truetype-font",                            { "ttf", "otf", "ttc" }                                         },
   { "application/x-ustar",                                    { "ustar" }                                              },
   { "application/x-wais-source",                              { "src" }                                                },
   { "application/x-wingz",                                    { "wz" }                                                 },


### PR DESCRIPTION
TrueType Font Collections are just files packing some TrueType Font together. As far as I can tell it's fine to handle them just like any other TTF file. Does that seem acceptable to you?
